### PR TITLE
Do not run R in "vanilla" mode

### DIFF
--- a/vtl-bundles/vtl-r/RVTL/src/main/resources/scripts/build-r.sh
+++ b/vtl-bundles/vtl-r/RVTL/src/main/resources/scripts/build-r.sh
@@ -29,7 +29,7 @@ FILENAME="$PWD/${project.artifactId}_${r.package.version}.tar.gz"
 
 echo Building: $FILENAME
 
-echo 'roxygen2::roxygenize("../classes/R")' | "${r.prepend.path}R" --vanilla -q
+echo 'roxygen2::roxygenize("../classes/R")' | "${r.prepend.path}R" -q
 
 if [ '${maven.test.skip}' != 'true' ]; then
 	rm -rf ${project.artifactId}.Rcheck


### PR DESCRIPTION
The  `--vanilla` flag resets the user library (e.g. when set via the `R_LIBS` in `~/.Renviron`)